### PR TITLE
Some further update/corrections

### DIFF
--- a/TeensyWinkeyEmulator.ino
+++ b/TeensyWinkeyEmulator.ino
@@ -452,6 +452,37 @@ void speed_set(int teensyspeed) {
   Speed=teensyspeed;
 }
 
+void keyer_autoptt_set(int enable) {
+  //
+  // Interface to let the TeensyUSBAudioMidi class
+  // set the "use PTT" flag.
+  //
+  PinConfig |= 0x01;
+}
+
+void keyer_leadin_set(int t) {
+  //
+  // Interface to let the TeensyUSBAudioMidi class
+  // set the lead-in time. The time is rounded to the
+  // next multiple of 10 (milli-seconds)
+  //
+  LeadIn = (t + 5)/10;
+}
+
+void keyer_hang_set(int hang) {
+  //
+  // Interface to let the TeensyUSBAudioMidi class
+  // set the "PTT hang" time. The time is in
+  // dot-lengths so it varies with the CW speed.
+  // Note: WinKeyer encodes 8/9/11/15 dot lengths in HANGBITS
+  //
+  Tail=0;
+  PinConfig &= 0x30;                               //  8 dot lengths hang time
+  if (hang >=  9  && hang <10) PinConfig |= 0x01;  //  9 dot lengths hang time
+  if (hang >= 11  && hang <13) PinConfig |= 0x02;  // 11 dot lengths hang time
+  if (hang >= 14)              PinConfig |= 0x03;  // 15 dot lengths hang time
+}
+
 TeensyUSBAudioMidi teensyusbaudiomidi(AUDIO_OUTPUT,
 									  SIDETONE_FREQ,
 									  SIDETONE_VOLUME,

--- a/src/TeensyUSBAudioMidi/TeensyAudioTone.h
+++ b/src/TeensyUSBAudioMidi/TeensyAudioTone.h
@@ -28,8 +28,6 @@
 #include "AudioStream.h"
 #include "arm_math.h"
 
-void speed_set(int);
-
 class TeensyAudioTone : public AudioStream
 {
 public:

--- a/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.cpp
+++ b/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.cpp
@@ -33,180 +33,188 @@
 
 void TeensyUSBAudioMidi::setup(void)
 {
-	AudioMemory(32);
-	AudioNoInterrupts();
+  AudioMemory(32);
+  AudioNoInterrupts();
 
-	if (Pin_SideToneFrequency >= 0) pinMode(Pin_SideToneFrequency, INPUT);
-	if (Pin_SideToneVolume	  >= 0) pinMode(Pin_SideToneVolume,    INPUT);
-	if (Pin_MasterVolume	  >= 0) pinMode(Pin_MasterVolume,	   INPUT);
-	if (Pin_Speed			  >= 0) pinMode(Pin_Speed,			   INPUT);
+  if (Pin_SideToneFrequency >= 0) pinMode(Pin_SideToneFrequency, INPUT);
+  if (Pin_SideToneVolume    >= 0) pinMode(Pin_SideToneVolume,    INPUT);
+  if (Pin_MasterVolume      >= 0) pinMode(Pin_MasterVolume,      INPUT);
+  if (Pin_Speed             >= 0) pinMode(Pin_Speed,             INPUT);
 
-	sine.frequency(default_freq);
-	sine_level=default_level;
-	sine.amplitude(sine_level);
+  sine.frequency(default_freq);
+  sine_level=default_level;
+  sine.amplitude(sine_level);
 
-	if (wm8960) {
-	  wm8960->enable();
-	  wm8960->volume(0.8F);
-	}
-	if (sgtl5000) {
-	  sgtl5000->enable();
-	  sgtl5000->volume(0.8F);
-	}
+  if (wm8960) {
+    wm8960->enable();
+    wm8960->volume(0.8F);
+  }
+  if (sgtl5000) {
+    sgtl5000->enable();
+    sgtl5000->volume(0.8F);
+  }
 
-	AudioInterrupts();
+  AudioInterrupts();
 
 #ifndef DL1YCF_POTS
-	analogReadRes(12);
-	analogReadAveraging(40);
+  analogReadRes(12);
+  analogReadAveraging(40);
 #endif
 
 }
 
 void TeensyUSBAudioMidi::loop(void)
 {
-	if (enable_pots) { pots(); }
-	midi();
+  if (enable_pots) { pots(); }
+  midi();
 }
 
 
 void TeensyUSBAudioMidi::midi(void)
 {
-	uint cmd, data;
-	static uint32_t lsb_data = 0;  // in case we need BIG numbers (currently unused)
+  uint cmd, data;
+  static uint32_t lsb_data = 0;  // in case we need BIG numbers (currently unused)
 
-	//
-	// "swallow" incoming MIDI messages on ANY channel,
-	// but only process those on MIDI_CONTROL_CHANNEL.
-	// This is to prevent overflows if MIDI messages are
-	// sent on the "wrong" channel.
-	//
-	while (usbMIDI.read()) {
-		if (usbMIDI.getType() == usbMIDI.ControlChange) {
-			cmd  = usbMIDI.getData1();
-			data = usbMIDI.getData2();
+  //
+  // "swallow" incoming MIDI messages on ANY channel,
+  // but only process those on MIDI_CONTROL_CHANNEL.
+  // This is to prevent overflows if MIDI messages are
+  // sent on the "wrong" channel.
+  //
+  while (usbMIDI.read()) {
+    if (usbMIDI.getType() == usbMIDI.ControlChange) {
+      cmd  = usbMIDI.getData1();
+      data = usbMIDI.getData2();
 
-		// Accept setting of control channel on any channel
-		if (cmd == MIDI_RX_CH) {
-			midi_rx_ch = data & 0x0f;
-		}
+      // Accept setting of control channel on any channel
+      if (cmd == MIDI_RX_CH) {
+        midi_rx_ch = data & 0x0f;
+      }
 
-		if (usbMIDI.getChannel() == midi_rx_ch) {
-			switch(cmd) {
-				case MIDI_SET_ACCUM:
-					// Set lsb_data for > 7 bit values
-					lsb_data = data;
-					break;
+      if (usbMIDI.getChannel() == midi_rx_ch) {
+        switch(cmd) {
+          case MIDI_SET_ACCUM:
+            // Set lsb_data for > 7 bit values
+            lsb_data = data;
+            break;
 
-				case MIDI_SHIFT_ACCUM:
-					// Set lsb_data for > 7 bit values
-					lsb_data = (lsb_data << 7) | data;
-					break;
+          case MIDI_SHIFT_ACCUM:
+            // Set lsb_data for > 7 bit values
+            lsb_data = (lsb_data << 7) | data;
+            break;
 
-				case MIDI_MASTER_VOLUME:
-					mastervolume((data << 6)+31);
-					break;
+          case MIDI_MASTER_VOLUME:
+            mastervolume((data << 6)+31);
+            break;
 
-				case MIDI_SIDETONE_VOLUME:
-					sidetonevolume((data << 6)+31);
-					break;
+          case MIDI_SIDETONE_VOLUME:
+            sidetonevolume((data << 6)+31);
+            break;
 
-				case MIDI_SIDETONE_FREQUENCY:
-					sidetonefrequency((data << 6)+31);
-					break;
+          case MIDI_SIDETONE_FREQUENCY:
+            sidetonefrequency((data << 6)+31);
+            break;
 
-				case MIDI_CW_SPEED:
-					speed_set(data);  // report to keyer
-					cwspeed(data);	  // report to radio
-					break;
+          case MIDI_CW_SPEED:
+            speed_set(data);  // report to keyer
+            cwspeed(data);    // report to radio (and MIDI controller)
+            break;
 
-				case MIDI_ENABLE_POTS:
-					enable_pots = data;
-					break;
+          case MIDI_ENABLE_POTS:
+            enable_pots = data;
+            break;
 
-				case MIDI_TX_CH:
-					midi_tx_ch = data & 0x0f;
-					break;
+          case MIDI_CWPTT_ONOFF:
+            keyer_cwptt_set(data);  // report to keyer
+            break;
 
-				case MIDI_KEYDOWN_NOTE:
-					midi_keydown_note = data;
-					break;
+          case MIDI_TX_CH:
+            midi_tx_ch = data & 0x0f;
+            break;
 
-				case MIDI_PTT_MIC_NOTE:
-					midi_ptt_mic_note = data;
-					break;
+          case MIDI_KEYDOWN_NOTE:
+            midi_keydown_note = data;
+            break;
 
-				case MIDI_PTT_IN_NOTE:
-					midi_ptt_in_note = data;
-					break;
+          case MIDI_PTT_MIC_NOTE:
+            midi_ptt_mic_note = data;
+            break;
 
-				case MIDI_CWPTT_NOTE:
-					midi_cwptt_note = data;
-					break;
+          case MIDI_PTT_IN_NOTE:
+            midi_ptt_in_note = data;
+            break;
 
-				case MIDI_SPEED_RESP_CTRL:
-					midi_speed_ctrl = data;
-					break;
+          case MIDI_CWPTT_NOTE:
+            midi_cwptt_note = data;
+            break;
 
-				case MIDI_FREQ_RESP_CTRL:
-					midi_freq_ctrl = data;
-					break;
+          case MIDI_SPEED_NOTE:
+            midi_speed_note = data;
+            break;
 
-				default:
-					break;
-			}
-		}
-	}
-}
+          case MIDI_RESPONSE:
+            midi_response = data;
+            break;
+
+          case MIDI_FREQ_NOTE:
+            midi_freq_note = data;
+            break;
+
+          default :
+            break;
+        }
+      }
+    }
+  }
 }
 
 
 #ifdef DL1YCF_POTS
 
 void TeensyUSBAudioMidi::pots() {
-	unsigned long now;
-	//
-	// handle analog lines, but only one analogRead every 5 msec
-	// in case of overflow, trigger read.
-	// Read all four input lines in round-robin fashion
-	//
-	now = millis();
-	if (now < last_analog_read) last_analog_read = now; // overflow recovery
-	if (now > last_analog_read +5) {
-	  last_analog_read = now;
-	  switch (last_analog_line++) {
-		case 0:  // SideToneFrequency
-		  if (Pin_SideToneFrequency >= 0) {
-			if (analogDenoise(Pin_SideToneFrequency, &Analog_SideFreq, &last_sidefreq)) {
-			  sidetonefrequency(400+30*last_sidefreq);	// 400 ... 1000 Hz in 30 Hz steps
-			}
-		  }
-		  break;
-		case 1: // SideToneVolume
-		  if (Pin_SideToneVolume >= 0) {
-			if (analogDenoise(Pin_SideToneVolume, &Analog_SideVol, &last_sidevol)) {
-			  sidetonevolume(last_sidevol);
-			}
-		  }
-		  break;
-		case 2: // Master Volume
-		  if (Pin_MasterVolume >= 0) {
-			if (analogDenoise(Pin_MasterVolume, &Analog_MasterVol, &last_mastervol)) {
-			  mastervolume(last_mastervol);
-			}
-		  }
-		  break;
-		case 3: // Speed
-		  if (Pin_Speed >= 0) {
-			if (analogDenoise(Pin_Speed, &Analog_Speed, &last_speed)) {
-			  speed_set(10+last_speed);	// report to keyer
-			  cwspeed(10+last_speed);	// report to radio
-			}
-		  }
-		  last_analog_line=0;	// roll over
-		  break;
-	  }
-	}
+  unsigned long now;
+  //
+  // handle analog lines, but only one analogRead every 5 msec
+  // in case of overflow, trigger read.
+  // Read all four input lines in round-robin fashion
+  //
+  now = millis();
+  if (now < last_analog_read) last_analog_read = now; // overflow recovery
+  if (now > last_analog_read +5) {
+    last_analog_read = now;
+    switch (last_analog_line++) {
+      case 0:  // SideToneFrequency
+        if (Pin_SideToneFrequency >= 0) {
+          if (analogDenoise(Pin_SideToneFrequency, &Analog_SideFreq, &last_sidefreq)) {
+            sidetonefrequency(400+30*last_sidefreq);  // 400 ... 1000 Hz in 30 Hz steps
+          }
+        }
+        break;
+      case 1: // SideToneVolume
+        if (Pin_SideToneVolume >= 0) {
+          if (analogDenoise(Pin_SideToneVolume, &Analog_SideVol, &last_sidevol)) {
+            sidetonevolume(last_sidevol);
+          }
+        }
+        break;
+      case 2: // Master Volume
+        if (Pin_MasterVolume >= 0) {
+          if (analogDenoise(Pin_MasterVolume, &Analog_MasterVol, &last_mastervol)) {
+            mastervolume(last_mastervol);
+          }
+        }
+        break;
+      case 3: // Speed
+        if (Pin_Speed >= 0) {
+          if (analogDenoise(Pin_Speed, &Analog_Speed, &last_speed)) {
+            speed_set(10+last_speed); // report to keyer
+            cwspeed(10+last_speed);   // report to radio
+          }
+        }
+        last_analog_line=0;   // roll over
+        break;
+    }
+  }
 }
 
 bool TeensyUSBAudioMidi::analogDenoise(int pin, uint16_t *value, uint8_t *old) {
@@ -227,8 +235,8 @@ bool TeensyUSBAudioMidi::analogDenoise(int pin, uint16_t *value, uint8_t *old) {
   // The value is then converted to the scale 0-20 and the new scale value
   // is stored in *old. The conversion is done as follows:
   //
-  // value =	 0 ...	 779   ==> reading =  0
-  // value =   780 ...	1559   ==> reading =  1
+  // value =     0 ...   779   ==> reading =  0
+  // value =   780 ...  1559   ==> reading =  1
   // ...
   // value = 15600 ... 16368   ==> reading = 20
   //
@@ -259,13 +267,13 @@ bool TeensyUSBAudioMidi::analogDenoise(int pin, uint16_t *value, uint8_t *old) {
   if (newval > 16368) newval=16368; // pure paranoia
   *value = newval;
 
-  midpoint = 390 + 780 * *old;	// midpoint of interval corresponding to "old" value
+  midpoint = 390 + 780 * *old;  // midpoint of interval corresponding to "old" value
 
   if (newval > midpoint + 600 || (midpoint > 780 && newval < midpoint - 600)) {
-	*old = newval / 780; // range 0 ... 20
-	return true;
+    *old = newval / 780; // range 0 ... 20
+    return true;
   } else {
-	return false;
+    return false;
   }
 }
 
@@ -273,70 +281,70 @@ bool TeensyUSBAudioMidi::analogDenoise(int pin, uint16_t *value, uint8_t *old) {
 
 void TeensyUSBAudioMidi::pots()
 {
-	uint16_t analog_data;
-	unsigned long m = millis();
+  uint16_t analog_data;
+  unsigned long m = millis();
 
-	// Call every 10 ms, will handle rollover as both m and last_analog_read are unsigned long
-	if ((m - last_analog_read) > 10) {
+  // Call every 10 ms, will handle rollover as both m and last_analog_read are unsigned long
+  if ((m - last_analog_read) > 10) {
 
-		if (last_analog_line == 0) {
-			// Master volume
-			analog_data = analogRead(Pin_MasterVolume);
-			// At 12 bit this averaging will produce a value in the 0 to 8191 range, 13 bits
-			Analog_MasterVol = (Analog_MasterVol >> 1) + analog_data;
+    if (last_analog_line == 0) {
+      // Master volume
+      analog_data = analogRead(Pin_MasterVolume);
+      // At 12 bit this averaging will produce a value in the 0 to 8191 range, 13 bits
+      Analog_MasterVol = (Analog_MasterVol >> 1) + analog_data;
 
-			// Volume is 80 values, so only care if more than about 2**7 bit change
-			if (abs(Analog_MasterVol - last_mastervol) > 64) {
-				mastervolume(8191-Analog_MasterVol);
-				last_mastervol = Analog_MasterVol;
-				//Serial.print("MV ");
-				//Serial.println(analog_data);
-			}
-		} else if (last_analog_line == 1) {
+      // Volume is 80 values, so only care if more than about 2**7 bit change
+      if (abs(Analog_MasterVol - last_mastervol) > 64) {
+        mastervolume(8191-Analog_MasterVol);
+        last_mastervol = Analog_MasterVol;
+        //Serial.print("MV ");
+        //Serial.println(analog_data);
+      }
+    } else if (last_analog_line == 1) {
 
-			// Sidetone volume
-			analog_data = analogRead(Pin_SideToneVolume);
-			Analog_SideVol = (Analog_SideVol >> 1) + analog_data;
-			// Sidetone volume has 32 entries so 5 bits
-			if (abs(Analog_SideVol - last_sidevol) > 256) {
-				sidetonevolume(8191-Analog_SideVol);
-				last_sidevol = Analog_SideVol;
-				//Serial.print("SV ");
-				//Serial.println(analog_data);
-			}
-		} else if (last_analog_line == 2) {
+      // Sidetone volume
+      analog_data = analogRead(Pin_SideToneVolume);
+      Analog_SideVol = (Analog_SideVol >> 1) + analog_data;
+      // Sidetone volume has 32 entries so 5 bits
+      if (abs(Analog_SideVol - last_sidevol) > 256) {
+        sidetonevolume(8191-Analog_SideVol);
+        last_sidevol = Analog_SideVol;
+        //Serial.print("SV ");
+        //Serial.println(analog_data);
+      }
+    } else if (last_analog_line == 2) {
 
-			// Sidetone frequency
-			analog_data = analogRead(Pin_SideToneFrequency);
-			Analog_SideFreq = (Analog_SideFreq >> 1) + analog_data;
-			// Range between 250 and 1274, 10 bits
-			if (abs(Analog_SideFreq - last_sidefreq) > 64) {
-				// Range between 100 and 2147 hz
-				sidetonefrequency(8191-Analog_SideFreq);
-				last_sidefreq = Analog_SideFreq;
-				//Serial.print("SF ");
-				//Serial.println(analog_data);
-			}
-		} else if (last_analog_line == 3) {
+      // Sidetone frequency
+      analog_data = analogRead(Pin_SideToneFrequency);
+      Analog_SideFreq = (Analog_SideFreq >> 1) + analog_data;
+      // Range between 250 and 1274, 10 bits
+      if (abs(Analog_SideFreq - last_sidefreq) > 64) {
+        // Range between 100 and 2147 hz
+        sidetonefrequency(8191-Analog_SideFreq);
+        last_sidefreq = Analog_SideFreq;
+        //Serial.print("SF ");
+        //Serial.println(analog_data);
+      }
+    } else if (last_analog_line == 3) {
 
-			// Speed
-			analog_data = analogRead(Pin_Speed);
-			Analog_Speed = (Analog_Speed >> 1) + analog_data;
-			// range between 1 and 65 WPM via pot, 6 bits
-			if (abs(Analog_Speed - last_speed) > 128) {
-				speed_set((8191-Analog_Speed)>>7);	// report to keyer
-				cwspeed((8191-Analog_Speed)>>7);	// report to radio
-				last_speed = Analog_Speed;
-				//Serial.print("SP ");
-				//Serial.println(pot_speed);
-				//Serial.print(" ");
-				//Serial.println(analog_data);
-			}
-		}
+      // Speed
+      analog_data = analogRead(Pin_Speed);
+      Analog_Speed = (Analog_Speed >> 1) + analog_data;
+      // range between 1 and 65 WPM via pot, 6 bits
+      if (abs(Analog_Speed - last_speed) > 128) {
+        speed_set((8191-Analog_Speed)>>7);  // report to keyer
+        cwspeed((8191-Analog_Speed)>>7);    // report to radio
+        last_speed = Analog_Speed;
+        //Serial.print("SP ");
+        //Serial.println(pot_speed);
+        //Serial.print(" ");
+        //Serial.println(analog_data);
+      }
+    }
 
-		last_analog_read = m;
-		last_analog_line = (last_analog_line + 1) & 0x3;
-	}
+    last_analog_read = m;
+    last_analog_line = (last_analog_line + 1) & 0x3;
+  }
 }
 
 #endif
@@ -344,77 +352,92 @@ void TeensyUSBAudioMidi::pots()
 
 void TeensyUSBAudioMidi::key(int state)
 {
-	teensyaudiotone.setTone(state);
-	if (midi_keydown_note >= 0 && midi_tx_ch > 0) {
-		usbMIDI.sendNoteOn(midi_keydown_note, state ? 127 : 0, midi_tx_ch);
-		usbMIDI.send_now();
-	}
+  teensyaudiotone.setTone(state);
+  if (midi_keydown_note > 0 && midi_tx_ch > 0) {
+     usbMIDI.sendNoteOn(midi_keydown_note, state ? 127 : 0, midi_tx_ch);
+     usbMIDI.send_now();
+  }
 }
 
 void TeensyUSBAudioMidi::cwptt(int state)
 {
-	if (mute_on_cwptt) {
-	  //
-	  // This mutes the audio from the PC but not the side tone
-	  //
-	  teensyaudiotone.muteAudioIn(state);
-	}
-	if (midi_cwptt_note >= 0 && midi_tx_ch > 0) {
-		usbMIDI.sendNoteOn(midi_cwptt_note, state ? 127 : 0, midi_tx_ch);
-	}      
+  if (mute_on_cwptt) {
+    //
+    // This mutes the audio from the PC but not the side tone
+    //
+    teensyaudiotone.muteAudioIn(state);
+  }
+  if (midi_cwptt_note > 0 && midi_tx_ch > 0) {
+    usbMIDI.sendNoteOn(midi_cwptt_note, state ? 127 : 0, midi_tx_ch);
+  }
 }
 
 
 // Expected level is 0 to 8191
 void TeensyUSBAudioMidi::mastervolume(uint16_t level)
 {
-	// Ease reaching max and minimum values
-	if (level > 8158) level = 8191;
-	if (level < 33) level = 0;
+  // Ease reaching max and minimum values
+  if (level > 8158) level = 8191;
+  if (level < 33) level = 0;
 
-	if (sgtl5000) {
-		sgtl5000->volume(((float)level)/8191.0);
-	}
-	if (wm8960) {
-		wm8960->volume(((float)level)/8191.0);
-	}
+  if (midi_response) {
+    usbMIDI.sendControlChange(MIDI_MASTER_VOLUME, (level>>6)&0x7f, midi_rx_ch); // send to MIDI controller
+  }
+  if (sgtl5000) {
+    sgtl5000->volume(((float)level)/8191.0);
+  }
+  if (wm8960) {
+    wm8960->volume(((float)level)/8191.0);
+  }
 }
 
 // Expected level is 0 to 8191
 void TeensyUSBAudioMidi::sidetonevolume(uint16_t level)
 {
-	//
-	// The input value (level) is in the range 0-31 and converted to
-	// an amplitude using VolTab, such that a logarithmic pot is
-	// simulated.
-	//
-	// Reduce to 5 bits
-	level = (level >> 8) & 0x1f;
-	sine.amplitude(VolTab[level]);
+  //
+  // The input value (level) is in the range 0-31 and converted to
+  // an amplitude using VolTab, such that a logarithmic pot is
+  // simulated.
+  //
+  // Reduce to 5 bits
+  level = (level >> 8) & 0x1f;
+  sine.amplitude(VolTab[level]);
 }
 
 // Expected input value is 0 to 8191, maps to range 250 to about 1270Hz
+// 
 void TeensyUSBAudioMidi::sidetonefrequency(uint16_t freq)
 {
-	sine.frequency( 250+((float)freq)/8.0 );
+  sine.frequency( 250+((float)freq)/8.0 );
 
-	if (midi_freq_ctrl >= 0 && midi_tx_ch > 0) {
-		usbMIDI.sendControlChange(midi_freq_ctrl, (freq<<6)&0x7f, midi_tx_ch);
-	}
+  if (midi_freq_note > 0 && midi_tx_ch > 0) {
+    //
+    // In the radio, the frequency has to be calculated as
+    // freq = 250 + 8*val, where val is the controller value 0<= val <= 127
+    //
+    usbMIDI.sendControlChange(midi_freq_note, (freq>>6)&0x7f, midi_tx_ch); // send  to radio
+  }
+  if (midi_response) {
+    usbMIDI.sendControlChange(MIDI_SIDETONE_FREQUENCY, (freq>>6)&0x7f, midi_rx_ch); // send to MIDI controller
+  }
 }
 
 // Expected speed is 1 to 127, don't use high values if not desired, no fractional CW speeds
 void TeensyUSBAudioMidi::cwspeed(uint16_t speed)
 {
-	if (speed == 0) speed = 1;
-	if (speed > 127) speed = 127;
+  if (speed == 0) speed = 1;
+  if (speed > 127) speed = 127;
 
-	if (midi_speed_ctrl >= 0 && midi_tx_ch > 0) {
-		// Simple conversion as no fractional speeds
-		// MIDI does not have to use large speeds
-		usbMIDI.sendControlChange(midi_speed_ctrl, speed&0x7f, midi_tx_ch);
-	}
- }
+  if (midi_speed_note > 0 && midi_tx_ch > 0) {
+    //
+    // In the radio, the controller value (1 <= val <= 127) encodes the speed
+    //
+    usbMIDI.sendControlChange(midi_speed_note, speed&0x7f, midi_tx_ch);  // send to radio
+  }
+  if (midi_response) {
+    usbMIDI.sendControlChange(MIDI_CW_SPEED, speed&0x7f, midi_rx_ch);    // send to MIDI controller
+  }
+}
 
 
 

--- a/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.h
+++ b/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.h
@@ -30,214 +30,219 @@
 #include "TeensyAudioTone.h"
 
 enum midi_control_selection {
-  MIDI_SET_ACCUM		   = 0,
-  MIDI_SHIFT_ACCUM		   = 1,
+  MIDI_SET_ACCUM           = 0,		// initiate multi-byte value
+  MIDI_SHIFT_ACCUM         = 1,		// update multi-bye value
 
-  MIDI_MASTER_VOLUME	   = 4,		// set master volume
-  MIDI_SIDETONE_VOLUME	   = 5,		// set sidetone volume
+  MIDI_MASTER_VOLUME       = 4,		// set master volume
+  MIDI_SIDETONE_VOLUME     = 5,		// set sidetone volume
   MIDI_SIDETONE_FREQUENCY  = 6,		// set sidetone frequency
-  MIDI_CW_SPEED			   = 7,		// set CW speed
-  MIDI_ENABLE_POTS		   = 8,		// enable potentiometers
+  MIDI_CW_SPEED            = 7,		// set CW speed
+  MIDI_ENABLE_POTS         = 8,		// enable/disable potentiometers
+  MIDI_CWPTT_ONOFF         = 9,		// enable/disable PTT from CW keyer
+  MIDI_KEYER_LEADIN        = 10,        // set Keyer lead-in time (for CWPTT)
+  MIDI_KEYER_HANG          = 11,        // set Keyer hang time (for CWPTT)
+  MIDI_RESPONSE            = 12,	// enable/disable reporting back to MIDI controller
 
-  MIDI_RX_CH			   = 16,	// set MIDI channel to listen to
-  MIDI_TX_CH			   = 17,	// set MIDI channel to write to
-  MIDI_KEYDOWN_NOTE		   = 18,	// set MIDI note value for key-down (to radio)
-  MIDI_PTT_MIC_NOTE		   = 19,
-  MIDI_PTT_IN_NOTE		   = 20,
-  MIDI_CWPTT_NOTE		   = 21,	// set MIDI note value for PTT activation (to radio)
-  MIDI_SPEED_RESP_CTRL     = 22,	// set MIDI controller number for reporting speed to radio
-  MIDI_FREQ_RESP_CTRL	   = 23		// set MIDI controller number for reporting side tone frequency to radio
+  MIDI_RX_CH               = 16,	// set MIDI channel to/from controller
+  MIDI_TX_CH               = 17,	// set MIDI channel to radio
+
+  MIDI_KEYDOWN_NOTE        = 18,	// set MIDI note for key-down (to radio)
+  MIDI_PTT_MIC_NOTE        = 19,
+  MIDI_PTT_IN_NOTE         = 20,
+  MIDI_CWPTT_NOTE          = 21,	// set MIDI note value for PTT activation (to radio)
+  MIDI_SPEED_NOTE          = 22,    // set MIDI controller for cw speed (to radio)
+  MIDI_FREQ_NOTE           = 23,    // set MIDI controller for side tone frequency (to radio)
 };
 
 
 class TeensyUSBAudioMidi
 {
 public:
-	TeensyUSBAudioMidi (int i2s, int freq, double vol,
-						int pin_sidevol,
-						int pin_sidefreq,
-						int pin_mastervol,
-						int pin_speed) :
-	sine(),
-	usbaudioinput(),
-	teensyaudiotone(),
-	patchinl (usbaudioinput,   0, teensyaudiotone, 0),
-	patchinr (usbaudioinput,   1, teensyaudiotone, 1),
-	patchwav (sine,			   0, teensyaudiotone, 2) 
-	{
-	  default_freq	= freq;
-	  default_level = vol;
+  TeensyUSBAudioMidi(int i2s, int freq, double vol,
+                     int pin_sidevol, int pin_sidefreq, int pin_mastervol, int pin_speed) :
+  sine(),
+  usbaudioinput(),
+  teensyaudiotone(),
+  patchinl (usbaudioinput,   0, teensyaudiotone, 0),
+  patchinr (usbaudioinput,   1, teensyaudiotone, 1),
+  patchwav (sine,            0, teensyaudiotone, 2)
+  {
+    default_freq  = freq;
+    default_level = vol;
 
-	  Pin_SideToneFrequency = pin_sidefreq;
-	  Pin_SideToneVolume	= pin_sidevol;
-	  Pin_MasterVolume		= pin_mastervol;
-	  Pin_Speed				= pin_speed;
+    Pin_SideToneFrequency = pin_sidefreq;
+    Pin_SideToneVolume    = pin_sidevol;
+    Pin_MasterVolume      = pin_mastervol;
+    Pin_Speed             = pin_speed;
 
-	  //
-	  // Audio output. The audio output method is encoded in the i2s variable:
-	  //
-	  // i2s = 0:	MQS audio output, no master volume control
-	  // i2s = 1:	I2S audio output, assuming a WM8960   device
-	  // i2s = 2:		I2S audio output, assuming a SGTL5100 device
-	  //
-	  // use MQS as the default if an illegal value has been given
-	  //
-	  switch (i2s) {
-		case 0:
-		default:
-			audioout = new AudioOutputMQS;
-			break;
-		case 1:
-			audioout = new AudioOutputI2S;
-			audioin	 = new AudioInputI2S;
-			wm8960	 = new AudioControlWM8960;
-			break;
-		case 2:
-			audioout = new AudioOutputI2S;
-	  		audioin	 = new AudioInputI2S;
-			sgtl5000 = new AudioControlSGTL5000;
-			break;
-	  }
-	  //
-	  // Solder cables from teensyaudiotone to the just-initialized audio output
-	  //
-	  if (audioin) {
-		patchusboutl = new AudioConnection(*audioin, 0, usbaudiooutput, 0);
-		patchusboutr = new AudioConnection(*audioin, 1, usbaudiooutput, 1);
-	  }
-	  patchoutl = new AudioConnection(teensyaudiotone, 0, *audioout,		0);
-	  patchoutr = new AudioConnection(teensyaudiotone, 1, *audioout,		1);
-	}
+    //
+    // Audio output. The audio output method is encoded in the i2s variable:
+    //
+    // i2s = 0: MQS audio output, no master volume control
+    // i2s = 1: I2S audio output, assuming a WM8960   device
+    // i2s = 2:       I2S audio output, assuming a SGTL5100 device
+    //
+    // use MQS as the default if an illegal value has been given
+    //
+    switch (i2s) {
+      case 0:
+      default:
+        audioout = new AudioOutputMQS;
+        break;
+      case 1:
+        audioout  = new AudioOutputI2S;
+        audioin   = new AudioInputI2S;
+        wm8960    = new AudioControlWM8960;
+        break;
+      case 2:
+        audioout  = new AudioOutputI2S;
+        audioin   = new AudioInputI2S;
+        sgtl5000  = new AudioControlSGTL5000;
+        break;
+    }
+    //
+    // Solder cables from teensyaudiotone to the just-initialized audio output
+    //
+    if (audioin) {
+      patchusboutl = new AudioConnection(*audioin, 0, usbaudiooutput, 0);
+      patchusboutr = new AudioConnection(*audioin, 1, usbaudiooutput, 1);
+    }
+    patchoutl = new AudioConnection(teensyaudiotone, 0, *audioout,        0);
+    patchoutr = new AudioConnection(teensyaudiotone, 1, *audioout,        1);
+  }
 
-	void setup(void);										  // to be executed once upon startup
-	void loop(void);										  // to be executed at each heart beat
-	void midi(void);										  // MIDI loop
-	void pots(void);										  // Potentiometer loop
-	void key(int state);									  // CW Key up/down event
-	void cwptt(int state);									  // PTT open/close event triggered by keyer
+  void setup(void);                                         // to be executed once upon startup
+  void loop(void);                                          // to be executed at each heart beat
+  void midi(void);                                          // MIDI loop
+  void pots(void);                                          // Potentiometer loop
+  void key(int state);                                      // CW Key up/down event
+  void cwptt(int state);                                    // PTT open/close event triggered by keyer
 #ifdef POTS_DL1YCF
-	bool analogDenoise(int pin, uint16_t *val, uint8_t *old); // De-Noise analog input
+    bool analogDenoise(int pin, uint16_t *val, uint8_t *old); // De-Noise analog input
 #endif
-	void mastervolume(uint16_t level);							 // set master volume
-	void sidetonevolume(uint16_t level);					  // Change side tone volume
-	void sidetonefrequency(uint16_t freq);					  // Change side tone frequency
-	void cwspeed(uint16_t speed);							  // send CW speed event
-	void sidetoneenable(int onoff) {						  // enable/disable side tone
-	   teensyaudiotone.sidetoneenable(onoff);
-	}
+  void mastervolume(uint16_t level);                        // set master volume
+  void sidetonevolume(uint16_t level);                      // Change side tone volume
+  void sidetonefrequency(uint16_t freq);                    // Change side tone frequency
+  void cwspeed(uint16_t speed);                             // send CW speed event
+  void sidetoneenable(int onoff) {                          // enable/disable side tone
+    teensyaudiotone.sidetoneenable(onoff);
+  }
 
-	void set_midi_keydown_note(int v) { midi_keydown_note = v; }
-	void set_midi_ptt_mic_note(int v) { midi_ptt_mic_note = v; }
-	void set_midi_ptt_in_note(int v) { midi_ptt_in_note = v; }
-	void set_midi_cwptt_note(int v) { midi_cwptt_note = v; }
-    void set_midi_speed_ctrl(int v) { midi_speed_ctrl = v; }
-    void set_midi_freq_ctrl(int v)  { midi_freq_ctrl = v; }
-	void set_cwptt_mute_option(int v) { mute_on_cwptt = v; }
+  void set_midi_keydown_note(int v) { midi_keydown_note = v; }
+  void set_midi_ptt_mic_note(int v) { midi_ptt_mic_note = v; }
+  void set_midi_ptt_in_note(int v) { midi_ptt_in_note = v; }
+  void set_midi_cwptt_note(int v) { midi_cwptt_note = v; }
+  void set_midi_speed_note(int v) { midi_speed_note = v; }
+  void set_midi_freq_note(int v) { midi_freq_note = v; }
+  void set_cwptt_mute_option(int v) { mute_on_cwptt = v; }
 
-	void set_midi_rx_ch(int v) { midi_rx_ch = v; }
-	void set_midi_tx_ch(int v) { midi_tx_ch = v; }
+  void set_midi_rx_ch(int v) { midi_rx_ch = v; }
+  void set_midi_tx_ch(int v) { midi_tx_ch = v; }
 
 
 private:
-	AudioSynthWaveformSine	sine;				// free-running side tone oscillator
-	AudioInputUSB			usbaudioinput;		// Audio in from Computer
-	AudioOutputUSB          usbaudiooutput;     // Audio out to Computer
-	TeensyAudioTone			teensyaudiotone;	// Side tone mixer
-	AudioConnection			patchinl;			// Cable "L" from Audio-in to side tone mixer
-	AudioConnection			patchinr;			// Cable "R" from Audio-in to side tone mixer
-	AudioConnection			patchwav;			// Mono-Cable from Side tone oscillator to side tone mixer
-	AudioConnection         *patchusboutl=NULL;
-	AudioConnection         *patchusboutr=NULL;
-	//
-	// These are dynamically created, since they depend on the actual
-	// audio output device
-	//
-	AudioStream				*audioout=NULL;		// Audio output to headphone
-	AudioStream             *audioin=NULL;		// Audio output to computer
-	AudioControlSGTL5000	*sgtl5000=NULL;		// SGTL5000 output controller
-	AudioControlWM8960		*wm8960=NULL;		// WM8960 output controller
-	AudioConnection			*patchoutl=NULL;	// Cable "L" from side tone mixer to headphone
-	AudioConnection			*patchoutr=NULL;	// Cable "R" from side tone mixer to headphone
+  AudioSynthWaveformSine  sine;               // free-running side tone oscillator
+  AudioInputUSB           usbaudioinput;      // Audio in from Computer
+  AudioOutputUSB          usbaudiooutput;     // Audio out to Computer
+  TeensyAudioTone         teensyaudiotone;    // Side tone mixer
+  AudioConnection         patchinl;           // Cable "L" from Audio-in to side tone mixer
+  AudioConnection         patchinr;           // Cable "R" from Audio-in to side tone mixer
+  AudioConnection         patchwav;           // Mono-Cable from Side tone oscillator to side tone mixer
+  AudioConnection         *patchusboutl=NULL;
+  AudioConnection         *patchusboutr=NULL;
+  //
+  // These are dynamically created, since they depend on the actual
+  // audio output device
+  //
+  AudioStream             *audioout=NULL;     // Audio output to headphone
+  AudioStream             *audioin=NULL;      // Audio output to computer
+  AudioControlSGTL5000    *sgtl5000=NULL;     // SGTL5000 output controller
+  AudioControlWM8960      *wm8960=NULL;       // WM8960 output controller
+  AudioConnection         *patchoutl=NULL;    // Cable "L" from side tone mixer to headphone
+  AudioConnection         *patchoutr=NULL;    // Cable "R" from side tone mixer to headphone
 
-	float sine_level;							// store this to detect "no side tone volume"
+  float sine_level;                           // store this to detect "no side tone volume"
 
-	//
-	// MIDI note/channel values, TX lines.
-	// ATTN: the 16 midi channels are numbered 1-16 (not 0-15!),
-	//	 since this was designed for musicians not computer scientists.
-	//
-	int midi_rx_ch = 1;
-	int midi_tx_ch = 1;
+  //
+  // MIDI note/channel values for communication with the radio
+  // ATTN: the 16 midi channels are numbered 1-16 (not 0-15!),
+  //       since this was designed for musicians not computer scientists.
+  //
 
-	int midi_keydown_note     =  1;
-	int midi_ptt_mic_note     = -1;
-	int midi_ptt_in_note      = -1;
-	int midi_cwptt_note 	  = -1;
-	int midi_speed_ctrl		  = -1;
-	int midi_freq_ctrl		  = -1;
+  int midi_rx_ch = 2;
+  int midi_tx_ch = 1;
 
-	// Enable/disable POTS
-	uint8_t enable_pots       = 1;
+  int midi_keydown_note     =  1;
+  int midi_ptt_mic_note     = -1;
+  int midi_ptt_in_note      = -1;
+  int midi_cwptt_note       = -1;
+  int midi_speed_note       = -1;
+  int midi_freq_note        = -1;
 
-	//
-	// (Analog) inputs to monitor. A negative value indicates "do not use this feature"
-	//
-	int Pin_SideToneFrequency = -1;
-	int Pin_SideToneVolume	  = -1;
-	int Pin_MasterVolume	  = -1;
-	int Pin_Speed			  = -1;
+  // Enable/disable MIDI responses back to MIDI controller
+  int midi_response         = 0;
 
-	//
-	// current states of the analog input lines,
-	// kept for de-noising.
-	//
-	uint16_t Analog_SideFreq  = 0;
-	uint16_t Analog_SideVol   = 0;
-	uint16_t Analog_MasterVol = 0;
-	uint16_t Analog_Speed	  = 0;
+  // Enable/disable POTS
+  uint8_t enable_pots       = 1;
 
-	uint16_t last_sidefreq		   = 0;
-	uint16_t last_sidevol		   = 0;
-	uint16_t last_mastervol		   = 0;
-	uint16_t last_speed			   = 0;
-	//
-	// Initial side tone frequency and volume.
-	// In normal circumstances, these will be set very soon by the
-	// caller of this class
-	//
-	int  default_freq	  = 800;			// default side tone frequency
-	float default_level   = 0.2F;			// default side tone volume
+  //
+  // (Analog) inputs to monitor. A negative value indicates "do not use this feature"
+  //
+  int Pin_SideToneFrequency = -1;
+  int Pin_SideToneVolume    = -1;
+  int Pin_MasterVolume      = -1;
+  int Pin_Speed             = -1;
 
-	int mute_on_cwptt  = 0;					// If set, Audio from PC is muted while PTT is activated by the CW keyer
-											// This muting does not occur if PTT is activated by the MIC or the input jack
+  //
+  // current states of the analog input lines,
+  // kept for de-noising.
+  //
+  uint16_t Analog_SideFreq  = 0;
+  uint16_t Analog_SideVol   = 0;
+  uint16_t Analog_MasterVol = 0;
+  uint16_t Analog_Speed     = 0;
 
-	unsigned long last_analog_read = 0;  	// time of last analog read
-	unsigned int last_analog_line=0;		// which line was read last time
+  uint16_t last_sidefreq         = 0;
+  uint16_t last_sidevol          = 0;
+  uint16_t last_mastervol        = 0;
+  uint16_t last_speed            = 0;
+  //
+  // Initial side tone frequency and volume.
+  // In normal circumstances, these will be set very soon by the
+  // caller of this class
+  //
+  int  default_freq     = 800;    // default side tone frequency
+  float default_level   = 0.2F;   // default side tone volume
 
-	//
-	// Side tone level (amplitude), in 32 steps from zero to one, about 2 dB per step
-	// This is used to convert the value from the (linear) volume pot to an amplitude level
-	//
-	// Note: sidetonevolume() takes an integer argument between 0 and 31, and this data
-	//		 is then used to convert to an amplitude for the side tone oscillator
-	//
-	// math.pow(10,-3+x/10.3333) where x is integer value, -3 is number of decades, and 10.3333 is maxx/decades
-	// for i in range(0,32): print(math.pow(10, -2+i/15.5))
-	//
-	// Set first entry to zero to allow for "complete muting"
+  int mute_on_cwptt  = 0;              // If set, Audio from PC is muted while CWPTT is active
+
+  unsigned long last_analog_read = 0;  // time of last analog read
+  unsigned int last_analog_line=0;     // which line was read last time
+
+  //
+  // Side tone level (amplitude), in 32 steps from zero to one, about 2 dB per step
+  // This is used to convert the value from the (linear) volume pot to an amplitude level
+  //
+  // Note: sidetonevolume() takes an integer argument between 0 and 31, and this data
+  //       is then used to convert to an amplitude for the side tone oscillator
+  //
+  // math.pow(10,-3+x/10.3333) where x is integer value, -3 is number of decades, and 10.3333 is maxx/decades
+  // for i in range(0,32): print(math.pow(10, -2+i/15.5))
+  //
+  // Set first entry to zero to allow for "complete muting"
 
 
-	// 3 decades
-	//float VolTab[32]={0.000,0.00125,0.00156,0.00195,0.00244,0.00305,0.00381,0.00476,
-	//					0.00595,0.00743,0.00928,0.0116,0.0145,0.01812,0.02264,0.02829,
-	//					0.03535,0.04417,0.0552,0.06898,0.0862,0.10771,0.1346,0.1682,
-	//					0.21018,0.26264,0.3282,0.41012,0.51249,0.64041,0.80027,1.0000};
+  // 3 decades
+  //float VolTab[32]={0.000,0.00125,0.00156,0.00195,0.00244,0.00305,0.00381,0.00476,
+  //                  0.00595,0.00743,0.00928,0.0116,0.0145,0.01812,0.02264,0.02829,
+  //                  0.03535,0.04417,0.0552,0.06898,0.0862,0.10771,0.1346,0.1682,
+  //                  0.21018,0.26264,0.3282,0.41012,0.51249,0.64041,0.80027,1.0000};
 
-	//2 decades
-	float VolTab[32] = {0.00,0.0116,0.0135,0.0156,0.0181,0.021,0.0244,0.0283,
-						0.0328,0.0381,0.0442,0.0512,0.0595,0.069,0.08,0.0928,
-						0.1077,0.125,0.145,0.1682,0.1951,0.2264,0.2626,0.3047,
-						0.3535,0.4101,0.4758,0.552,0.6404,0.743,0.862,1.0};
+  //2 decades
+  float VolTab[32] = {0.00,0.0116,0.0135,0.0156,0.0181,0.021,0.0244,0.0283,
+                      0.0328,0.0381,0.0442,0.0512,0.0595,0.069,0.08,0.0928,
+                      0.1077,0.125,0.145,0.1682,0.1951,0.2264,0.2626,0.3047,
+                      0.3535,0.4101,0.4758,0.552,0.6404,0.743,0.862,1.0};
 
 };
 

--- a/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.h
+++ b/src/TeensyUSBAudioMidi/TeensyUSBAudioMidi.h
@@ -29,220 +29,231 @@
 #include "arm_math.h"
 #include "TeensyAudioTone.h"
 
-enum midi_control_selection {
-  MIDI_SET_ACCUM           = 0,		// initiate multi-byte value
-  MIDI_SHIFT_ACCUM         = 1,		// update multi-bye value
+//
+// External functions, to be implemented in the keyer
+// (at least as dummies)
+//
+void speed_set(int speed);			// set CW speed in keyer
+void keyer_autoptt_set(int enable);	// enable/disable PTT activation by keyer
+void keyer_leadin_set(int leadin);	// set keyer PTT lead-in time (leadin milli-seconds) (if using auto-PTT)
+void keyer_hang_set(int hang);		// set keyer PTT hang time (in *dotlengths*) (if using auto-PTT)
 
-  MIDI_MASTER_VOLUME       = 4,		// set master volume
-  MIDI_SIDETONE_VOLUME     = 5,		// set sidetone volume
+enum midi_control_selection {
+  MIDI_SET_ACCUM		   = 0,		// initiate multi-byte value
+  MIDI_SHIFT_ACCUM		   = 1,		// update multi-byte value
+
+  MIDI_MASTER_VOLUME	   = 4,		// set master volume
+  MIDI_SIDETONE_VOLUME	   = 5,		// set sidetone volume
   MIDI_SIDETONE_FREQUENCY  = 6,		// set sidetone frequency
-  MIDI_CW_SPEED            = 7,		// set CW speed
-  MIDI_ENABLE_POTS         = 8,		// enable/disable potentiometers
-  MIDI_CWPTT_ONOFF         = 9,		// enable/disable PTT from CW keyer
-  MIDI_KEYER_LEADIN        = 10,        // set Keyer lead-in time (for CWPTT)
-  MIDI_KEYER_HANG          = 11,        // set Keyer hang time (for CWPTT)
+  MIDI_CW_SPEED			   = 7,		// set CW speed
+  MIDI_ENABLE_POTS		   = 8,		// enable/disable potentiometers
+  MIDI_KEYER_AUTOPTT       = 9,		// enable/disable auto-PTT from CW keyer
+  MIDI_KEYER_LEADIN        = 10,	// set Keyer lead-in time (if auto-PTT active)
+  MIDI_KEYER_HANG          = 11,	// set Keyer hang time (if auto-PTT active)
   MIDI_RESPONSE            = 12,	// enable/disable reporting back to MIDI controller
 
-  MIDI_RX_CH               = 16,	// set MIDI channel to/from controller
-  MIDI_TX_CH               = 17,	// set MIDI channel to radio
+  MIDI_RX_CH			   = 16,	// set MIDI channel to/from controller
+  MIDI_TX_CH			   = 17,	// set MIDI channel to radio
 
-  MIDI_KEYDOWN_NOTE        = 18,	// set MIDI note for key-down (to radio)
-  MIDI_PTT_MIC_NOTE        = 19,
-  MIDI_PTT_IN_NOTE         = 20,
-  MIDI_CWPTT_NOTE          = 21,	// set MIDI note value for PTT activation (to radio)
-  MIDI_SPEED_NOTE          = 22,    // set MIDI controller for cw speed (to radio)
-  MIDI_FREQ_NOTE           = 23,    // set MIDI controller for side tone frequency (to radio)
+  MIDI_KEYDOWN_NOTE		   = 18,	// set MIDI note for key-down (to radio)
+  MIDI_PTT_MIC_NOTE		   = 19,
+  MIDI_PTT_IN_NOTE		   = 20,
+  MIDI_CWPTT_NOTE		   = 21,	// set MIDI note for PTT activation (to radio)
+  MIDI_SPEED_CTRL          = 22,	// set MIDI controller for cw speed (to radio)
+  MIDI_FREQ_CTRL     	   = 23		// set MIDI controller for side tone frequency (to radio)
 };
 
 
 class TeensyUSBAudioMidi
 {
 public:
-  TeensyUSBAudioMidi(int i2s, int freq, double vol,
-                     int pin_sidevol, int pin_sidefreq, int pin_mastervol, int pin_speed) :
-  sine(),
-  usbaudioinput(),
-  teensyaudiotone(),
-  patchinl (usbaudioinput,   0, teensyaudiotone, 0),
-  patchinr (usbaudioinput,   1, teensyaudiotone, 1),
-  patchwav (sine,            0, teensyaudiotone, 2)
-  {
-    default_freq  = freq;
-    default_level = vol;
+	TeensyUSBAudioMidi (int i2s, int freq, double vol,
+						int pin_sidevol,
+						int pin_sidefreq,
+						int pin_mastervol,
+						int pin_speed) :
+	sine(),
+	usbaudioinput(),
+	teensyaudiotone(),
+	patchinl (usbaudioinput,   0, teensyaudiotone, 0),
+	patchinr (usbaudioinput,   1, teensyaudiotone, 1),
+	patchwav (sine,			   0, teensyaudiotone, 2) 
+	{
+	  default_freq	= freq;
+	  default_level = vol;
 
-    Pin_SideToneFrequency = pin_sidefreq;
-    Pin_SideToneVolume    = pin_sidevol;
-    Pin_MasterVolume      = pin_mastervol;
-    Pin_Speed             = pin_speed;
+	  Pin_SideToneFrequency = pin_sidefreq;
+	  Pin_SideToneVolume	= pin_sidevol;
+	  Pin_MasterVolume		= pin_mastervol;
+	  Pin_Speed				= pin_speed;
 
-    //
-    // Audio output. The audio output method is encoded in the i2s variable:
-    //
-    // i2s = 0: MQS audio output, no master volume control
-    // i2s = 1: I2S audio output, assuming a WM8960   device
-    // i2s = 2:       I2S audio output, assuming a SGTL5100 device
-    //
-    // use MQS as the default if an illegal value has been given
-    //
-    switch (i2s) {
-      case 0:
-      default:
-        audioout = new AudioOutputMQS;
-        break;
-      case 1:
-        audioout  = new AudioOutputI2S;
-        audioin   = new AudioInputI2S;
-        wm8960    = new AudioControlWM8960;
-        break;
-      case 2:
-        audioout  = new AudioOutputI2S;
-        audioin   = new AudioInputI2S;
-        sgtl5000  = new AudioControlSGTL5000;
-        break;
-    }
-    //
-    // Solder cables from teensyaudiotone to the just-initialized audio output
-    //
-    if (audioin) {
-      patchusboutl = new AudioConnection(*audioin, 0, usbaudiooutput, 0);
-      patchusboutr = new AudioConnection(*audioin, 1, usbaudiooutput, 1);
-    }
-    patchoutl = new AudioConnection(teensyaudiotone, 0, *audioout,        0);
-    patchoutr = new AudioConnection(teensyaudiotone, 1, *audioout,        1);
-  }
+	  //
+	  // Audio output. The audio output method is encoded in the i2s variable:
+	  //
+	  // i2s = 0:	MQS audio output, no master volume control
+	  // i2s = 1:	I2S audio output, assuming a WM8960   device
+	  // i2s = 2:		I2S audio output, assuming a SGTL5100 device
+	  //
+	  // use MQS as the default if an illegal value has been given
+	  //
+	  switch (i2s) {
+		case 0:
+		default:
+			audioout = new AudioOutputMQS;
+			break;
+		case 1:
+			audioout = new AudioOutputI2S;
+			audioin	 = new AudioInputI2S;
+			wm8960	 = new AudioControlWM8960;
+			break;
+		case 2:
+			audioout = new AudioOutputI2S;
+	  		audioin	 = new AudioInputI2S;
+			sgtl5000 = new AudioControlSGTL5000;
+			break;
+	  }
+	  //
+	  // Solder cables from teensyaudiotone to the just-initialized audio output
+	  //
+	  if (audioin) {
+		patchusboutl = new AudioConnection(*audioin, 0, usbaudiooutput, 0);
+		patchusboutr = new AudioConnection(*audioin, 1, usbaudiooutput, 1);
+	  }
+	  patchoutl = new AudioConnection(teensyaudiotone, 0, *audioout,		0);
+	  patchoutr = new AudioConnection(teensyaudiotone, 1, *audioout,		1);
+	}
 
-  void setup(void);                                         // to be executed once upon startup
-  void loop(void);                                          // to be executed at each heart beat
-  void midi(void);                                          // MIDI loop
-  void pots(void);                                          // Potentiometer loop
-  void key(int state);                                      // CW Key up/down event
-  void cwptt(int state);                                    // PTT open/close event triggered by keyer
+	void setup(void);										  // to be executed once upon startup
+	void loop(void);										  // to be executed at each heart beat
+	void midi(void);										  // MIDI loop
+	void pots(void);										  // Potentiometer loop
+	void key(int state);									  // CW Key up/down event
+	void cwptt(int state);									  // PTT open/close event triggered by keyer
 #ifdef POTS_DL1YCF
-    bool analogDenoise(int pin, uint16_t *val, uint8_t *old); // De-Noise analog input
+	bool analogDenoise(int pin, uint16_t *val, uint8_t *old); // De-Noise analog input
 #endif
-  void mastervolume(uint16_t level);                        // set master volume
-  void sidetonevolume(uint16_t level);                      // Change side tone volume
-  void sidetonefrequency(uint16_t freq);                    // Change side tone frequency
-  void cwspeed(uint16_t speed);                             // send CW speed event
-  void sidetoneenable(int onoff) {                          // enable/disable side tone
-    teensyaudiotone.sidetoneenable(onoff);
-  }
+	void mastervolume(uint16_t level);							 // set master volume
+	void sidetonevolume(uint16_t level);					  // Change side tone volume
+	void sidetonefrequency(uint16_t freq);					  // Change side tone frequency
+	void cwspeed(uint16_t speed);							  // send CW speed event
+	void sidetoneenable(int onoff) {						  // enable/disable side tone
+	   teensyaudiotone.sidetoneenable(onoff);
+	}
 
-  void set_midi_keydown_note(int v) { midi_keydown_note = v; }
-  void set_midi_ptt_mic_note(int v) { midi_ptt_mic_note = v; }
-  void set_midi_ptt_in_note(int v) { midi_ptt_in_note = v; }
-  void set_midi_cwptt_note(int v) { midi_cwptt_note = v; }
-  void set_midi_speed_note(int v) { midi_speed_note = v; }
-  void set_midi_freq_note(int v) { midi_freq_note = v; }
-  void set_cwptt_mute_option(int v) { mute_on_cwptt = v; }
+	void set_midi_keydown_note(int v) { midi_keydown_note = v; }
+	void set_midi_ptt_mic_note(int v) { midi_ptt_mic_note = v; }
+	void set_midi_ptt_in_note(int v) { midi_ptt_in_note = v; }
+	void set_midi_cwptt_note(int v) { midi_cwptt_note = v; }
+    void set_midi_speed_ctrl(int v) { midi_speed_ctrl = v; }
+    void set_midi_freq_ctrl(int v)  { midi_freq_ctrl = v; }
+	void set_cwptt_mute_option(int v) { mute_on_cwptt = v; }
 
-  void set_midi_rx_ch(int v) { midi_rx_ch = v; }
-  void set_midi_tx_ch(int v) { midi_tx_ch = v; }
+	void set_midi_rx_ch(int v) { midi_rx_ch = v; }
+	void set_midi_tx_ch(int v) { midi_tx_ch = v; }
 
 
 private:
-  AudioSynthWaveformSine  sine;               // free-running side tone oscillator
-  AudioInputUSB           usbaudioinput;      // Audio in from Computer
-  AudioOutputUSB          usbaudiooutput;     // Audio out to Computer
-  TeensyAudioTone         teensyaudiotone;    // Side tone mixer
-  AudioConnection         patchinl;           // Cable "L" from Audio-in to side tone mixer
-  AudioConnection         patchinr;           // Cable "R" from Audio-in to side tone mixer
-  AudioConnection         patchwav;           // Mono-Cable from Side tone oscillator to side tone mixer
-  AudioConnection         *patchusboutl=NULL;
-  AudioConnection         *patchusboutr=NULL;
-  //
-  // These are dynamically created, since they depend on the actual
-  // audio output device
-  //
-  AudioStream             *audioout=NULL;     // Audio output to headphone
-  AudioStream             *audioin=NULL;      // Audio output to computer
-  AudioControlSGTL5000    *sgtl5000=NULL;     // SGTL5000 output controller
-  AudioControlWM8960      *wm8960=NULL;       // WM8960 output controller
-  AudioConnection         *patchoutl=NULL;    // Cable "L" from side tone mixer to headphone
-  AudioConnection         *patchoutr=NULL;    // Cable "R" from side tone mixer to headphone
+	AudioSynthWaveformSine	sine;				// free-running side tone oscillator
+	AudioInputUSB			usbaudioinput;		// Audio in from Computer
+	AudioOutputUSB          usbaudiooutput;     // Audio out to Computer
+	TeensyAudioTone			teensyaudiotone;	// Side tone mixer
+	AudioConnection			patchinl;			// Cable "L" from Audio-in to side tone mixer
+	AudioConnection			patchinr;			// Cable "R" from Audio-in to side tone mixer
+	AudioConnection			patchwav;			// Mono-Cable from Side tone oscillator to side tone mixer
+	AudioConnection         *patchusboutl=NULL;
+	AudioConnection         *patchusboutr=NULL;
+	//
+	// These are dynamically created, since they depend on the actual
+	// audio output device
+	//
+	AudioStream				*audioout=NULL;		// Audio output to headphone
+	AudioStream             *audioin=NULL;		// Audio output to computer
+	AudioControlSGTL5000	*sgtl5000=NULL;		// SGTL5000 output controller
+	AudioControlWM8960		*wm8960=NULL;		// WM8960 output controller
+	AudioConnection			*patchoutl=NULL;	// Cable "L" from side tone mixer to headphone
+	AudioConnection			*patchoutr=NULL;	// Cable "R" from side tone mixer to headphone
 
-  float sine_level;                           // store this to detect "no side tone volume"
+	float sine_level;							// store this to detect "no side tone volume"
 
-  //
-  // MIDI note/channel values for communication with the radio
-  // ATTN: the 16 midi channels are numbered 1-16 (not 0-15!),
-  //       since this was designed for musicians not computer scientists.
-  //
+	//
+	// MIDI note/channel values for communication with the radio
+	// ATTN: the 16 midi channels are numbered 1-16 (not 0-15!),
+	//	 since this was designed for musicians not computer scientists.
+	//
+	int midi_rx_ch = 2;
+	int midi_tx_ch = 1;
 
-  int midi_rx_ch = 2;
-  int midi_tx_ch = 1;
+	int midi_keydown_note     =  1;
+	int midi_ptt_mic_note     = -1;
+	int midi_ptt_in_note      = -1;
+	int midi_cwptt_note 	  = -1;
+	int midi_speed_ctrl		  = -1;
+	int midi_freq_ctrl		  = -1;
 
-  int midi_keydown_note     =  1;
-  int midi_ptt_mic_note     = -1;
-  int midi_ptt_in_note      = -1;
-  int midi_cwptt_note       = -1;
-  int midi_speed_note       = -1;
-  int midi_freq_note        = -1;
+	// Enable/disable MIDI responses back to MIDI controller
+	int midi_response         = 0;
 
-  // Enable/disable MIDI responses back to MIDI controller
-  int midi_response         = 0;
+	// Enable/disable POTS
+	uint8_t enable_pots       = 1;
 
-  // Enable/disable POTS
-  uint8_t enable_pots       = 1;
+	//
+	// (Analog) inputs to monitor. A negative value indicates "do not use this feature"
+	//
+	int Pin_SideToneFrequency = -1;
+	int Pin_SideToneVolume	  = -1;
+	int Pin_MasterVolume	  = -1;
+	int Pin_Speed			  = -1;
 
-  //
-  // (Analog) inputs to monitor. A negative value indicates "do not use this feature"
-  //
-  int Pin_SideToneFrequency = -1;
-  int Pin_SideToneVolume    = -1;
-  int Pin_MasterVolume      = -1;
-  int Pin_Speed             = -1;
+	//
+	// current states of the analog input lines,
+	// kept for de-noising.
+	//
+	uint16_t Analog_SideFreq  = 0;
+	uint16_t Analog_SideVol   = 0;
+	uint16_t Analog_MasterVol = 0;
+	uint16_t Analog_Speed	  = 0;
 
-  //
-  // current states of the analog input lines,
-  // kept for de-noising.
-  //
-  uint16_t Analog_SideFreq  = 0;
-  uint16_t Analog_SideVol   = 0;
-  uint16_t Analog_MasterVol = 0;
-  uint16_t Analog_Speed     = 0;
+	uint16_t last_sidefreq		   = 0;
+	uint16_t last_sidevol		   = 0;
+	uint16_t last_mastervol		   = 0;
+	uint16_t last_speed			   = 0;
+	//
+	// Initial side tone frequency and volume.
+	// In normal circumstances, these will be set very soon by the
+	// caller of this class
+	//
+	int  default_freq	  = 800;			// default side tone frequency
+	float default_level   = 0.2F;			// default side tone volume
 
-  uint16_t last_sidefreq         = 0;
-  uint16_t last_sidevol          = 0;
-  uint16_t last_mastervol        = 0;
-  uint16_t last_speed            = 0;
-  //
-  // Initial side tone frequency and volume.
-  // In normal circumstances, these will be set very soon by the
-  // caller of this class
-  //
-  int  default_freq     = 800;    // default side tone frequency
-  float default_level   = 0.2F;   // default side tone volume
+	int mute_on_cwptt  = 0;					// If set, Audio from PC is muted while CWPTT is active
 
-  int mute_on_cwptt  = 0;              // If set, Audio from PC is muted while CWPTT is active
+	unsigned long last_analog_read = 0;  	// time of last analog read
+	unsigned int last_analog_line=0;		// which line was read last time
 
-  unsigned long last_analog_read = 0;  // time of last analog read
-  unsigned int last_analog_line=0;     // which line was read last time
-
-  //
-  // Side tone level (amplitude), in 32 steps from zero to one, about 2 dB per step
-  // This is used to convert the value from the (linear) volume pot to an amplitude level
-  //
-  // Note: sidetonevolume() takes an integer argument between 0 and 31, and this data
-  //       is then used to convert to an amplitude for the side tone oscillator
-  //
-  // math.pow(10,-3+x/10.3333) where x is integer value, -3 is number of decades, and 10.3333 is maxx/decades
-  // for i in range(0,32): print(math.pow(10, -2+i/15.5))
-  //
-  // Set first entry to zero to allow for "complete muting"
+	//
+	// Side tone level (amplitude), in 32 steps from zero to one, about 2 dB per step
+	// This is used to convert the value from the (linear) volume pot to an amplitude level
+	//
+	// Note: sidetonevolume() takes an integer argument between 0 and 31, and this data
+	//		 is then used to convert to an amplitude for the side tone oscillator
+	//
+	// math.pow(10,-3+x/10.3333) where x is integer value, -3 is number of decades, and 10.3333 is maxx/decades
+	// for i in range(0,32): print(math.pow(10, -2+i/15.5))
+	//
+	// Set first entry to zero to allow for "complete muting"
 
 
-  // 3 decades
-  //float VolTab[32]={0.000,0.00125,0.00156,0.00195,0.00244,0.00305,0.00381,0.00476,
-  //                  0.00595,0.00743,0.00928,0.0116,0.0145,0.01812,0.02264,0.02829,
-  //                  0.03535,0.04417,0.0552,0.06898,0.0862,0.10771,0.1346,0.1682,
-  //                  0.21018,0.26264,0.3282,0.41012,0.51249,0.64041,0.80027,1.0000};
+	// 3 decades
+	//float VolTab[32]={0.000,0.00125,0.00156,0.00195,0.00244,0.00305,0.00381,0.00476,
+	//					0.00595,0.00743,0.00928,0.0116,0.0145,0.01812,0.02264,0.02829,
+	//					0.03535,0.04417,0.0552,0.06898,0.0862,0.10771,0.1346,0.1682,
+	//					0.21018,0.26264,0.3282,0.41012,0.51249,0.64041,0.80027,1.0000};
 
-  //2 decades
-  float VolTab[32] = {0.00,0.0116,0.0135,0.0156,0.0181,0.021,0.0244,0.0283,
-                      0.0328,0.0381,0.0442,0.0512,0.0595,0.069,0.08,0.0928,
-                      0.1077,0.125,0.145,0.1682,0.1951,0.2264,0.2626,0.3047,
-                      0.3535,0.4101,0.4758,0.552,0.6404,0.743,0.862,1.0};
+	//2 decades
+	float VolTab[32] = {0.00,0.0116,0.0135,0.0156,0.0181,0.021,0.0244,0.0283,
+						0.0328,0.0381,0.0442,0.0512,0.0595,0.069,0.08,0.0928,
+						0.1077,0.125,0.145,0.1682,0.1951,0.2264,0.2626,0.3047,
+						0.3535,0.4101,0.4758,0.552,0.6404,0.743,0.862,1.0};
 
 };
 


### PR DESCRIPTION
- added interfaces to the keyer for enabling/disabling automatic PTT, and for setting lead-in and hang times if using automatic PTT
- added MIDI commands (Controller ==> Keyer) for enabling/disabling keyer automatic PTT, and setting lead-in and hang times
- re-introduced MIDI messages for enabling/disabling MIDI messages to the controller (MIDI_RESPONSE)
- if  midi_response is enabled, trigger these messages when  master volume, side tone volume, side tone frequency or CW speed are changed
- changed default for MIDI_RX_CH from 1 to 2, since it should be different from MIDI_TX_CH (RX: communication with MIDI controller, TX: communication with radio)
- 